### PR TITLE
Fix: Pair to data_feed; changing impact config

### DIFF
--- a/experiments/simulation_configuration.py
+++ b/experiments/simulation_configuration.py
@@ -4,10 +4,10 @@ Default simulation_configuration configuration such as the number of timesteps a
 from model.constants import blocks_per_day, blocks_per_year
 
 BLOCKS_PER_TIMESTEP = 1  # number of blocks per timestep (=1 if sim on per-block-basis)
-SIMULATION_TIME_DAYS = 2  # number of days
+SIMULATION_TIME_DAYS = 1  # number of days
 # number of simulation_configuration timesteps
 TIMESTEPS = SIMULATION_TIME_DAYS * blocks_per_day // BLOCKS_PER_TIMESTEP
 TIMESTEPS_PER_YEAR = blocks_per_year // BLOCKS_PER_TIMESTEP
-MONTE_CARLO_RUNS = 2  # number of runs
-DATA_SOURCE = 'historical'   # 'mock' or 'historical'
+MONTE_CARLO_RUNS = 1  # number of runs
+DATA_SOURCE = 'mock'   # 'mock' or 'historical'
 TOTAL_BLOCKS = (BLOCKS_PER_TIMESTEP * TIMESTEPS) + 1

--- a/model/system_parameters.py
+++ b/model/system_parameters.py
@@ -213,16 +213,18 @@ parameters = InitParameters(
     ],
     impacted_assets=[[
         Pair(CryptoAsset.CELO, Fiat.USD),
+        Pair(CryptoAsset.CELO, Fiat.EUR),
+        Pair(CryptoAsset.CELO, Fiat.BRL),
         Pair(Stable.CUSD, Fiat.USD),
         Pair(Stable.CEUR, Fiat.EUR),
         Pair(Stable.CREAL, Fiat.BRL),
-        Pair(CryptoAsset.BTC, Fiat.USD),
-        Pair(CryptoAsset.ETH, Fiat.USD),
-        Pair(CryptoAsset.DAI, Fiat.USD),
+
     ]],
 
     variance_market_price=[{
         Pair(CryptoAsset.CELO, Fiat.USD): 1,
+        Pair(CryptoAsset.CELO, Fiat.EUR): 1,
+        Pair(CryptoAsset.CELO, Fiat.BRL): 1,
         Pair(Stable.CUSD, Fiat.USD): 0.01,
         Pair(Stable.CEUR, Fiat.EUR): 0.01,
         Pair(Stable.CREAL, Fiat.BRL): 0.01,

--- a/model/types/base.py
+++ b/model/types/base.py
@@ -2,13 +2,28 @@
 Various Python types used in the model
 """
 from __future__ import annotations
+from enum import Enum, EnumMeta
 from typing import TypedDict, Union
-from enum import Enum
 
 
 class SerializableEnum(Enum):
     def __str__(self):
         return self.value
+
+# pylint: disable=no-value-for-parameter
+
+
+class MetaEnum(EnumMeta):
+    def __contains__(cls, item):
+        try:
+            cls(item)
+        except ValueError:
+            return False
+        return True
+
+
+class ReflectiveSerializableEnum(SerializableEnum, metaclass=MetaEnum):
+    pass
 
 
 class TraderType(Enum):
@@ -20,7 +35,7 @@ class TraderType(Enum):
     MAX_TRADER = "SellMax"
 
 
-class Stable(SerializableEnum):
+class Stable(ReflectiveSerializableEnum):
     """
     Celo Stable assets
     """
@@ -29,14 +44,14 @@ class Stable(SerializableEnum):
     CEUR = "ceur"
 
 
-class CryptoAsset(SerializableEnum):
+class CryptoAsset(ReflectiveSerializableEnum):
     CELO = "celo"
     ETH = "eth"
     BTC = "btc"
     DAI = "dai"
 
 
-class Fiat(SerializableEnum):
+class Fiat(ReflectiveSerializableEnum):
     USD = "usd"
     EUR = "eur"
     BRL = "brl"

--- a/model/types/pair.py
+++ b/model/types/pair.py
@@ -47,6 +47,22 @@ class Pair(NamedTuple):
     def inverse(self) -> Pair:
         return Pair(self.quote, self.base)
 
+    @classmethod
+    def parse_from_string(cls, string):
+        """
+        Creating Pair from string 'baseccy_quoteccy'
+        """
+        base, quote = string.split('_')
+        assert base not in Fiat, f'Wrong quote convention used for {string}'
+        assert quote in Fiat, f'Wrong quote convention used for {string}'
+        if base in CryptoAsset:
+            base = CryptoAsset(base)
+        elif base in Stable:
+            base = Stable(base)
+        quote = Fiat(quote)
+
+        return Pair(base, quote)
+
     def get_rate(self, state: StateVariables) -> float:
         """
         Get the market rate for any pair as long as there's a path

--- a/model/utils/data_feed.py
+++ b/model/utils/data_feed.py
@@ -11,6 +11,7 @@ from experiments.simulation_configuration import DATA_SOURCE
 # pylint: disable = unused-import
 # pylint: disable = redefined-outer-name
 import data.mock_data  # this is necessary to create mock data if not existent
+from model.types.pair import Pair
 
 DATA_FOLDER = Path(__file__, "../../../data/").resolve()
 MOCK_DATA_FILE_NAME = "mock_logreturns.prq"
@@ -36,7 +37,8 @@ class DataFeed:
 
         self.data = np.array(self.historical_data)
         self.length = len(self.historical_data)
-        self.assets = list(self.historical_data.columns)
+        self.assets = [Pair.parse_from_string(name)
+                       for name in self.historical_data.columns]
 
     def load_mock_data(self, data_file_name):
         """
@@ -59,8 +61,10 @@ class DataFeed:
             raise NotImplementedError(f"File extension {file_extension} not supported")
 
         historical_log_returns = self.calculate_log_returns(historical_prices)
+        print(historical_log_returns)
         return historical_log_returns
 
+    # pylint: disable =no-self-use
     def calculate_log_returns(self, data_frame):
         """
         calculates log returns out of a data frame with price time series in its columns


### PR DESCRIPTION
This PR includes:
- a fix that adds parsing from string functionality to Pair to allow loading from data from files
- `ReflectiveSerializableEnum`, an extension of `SerializableEnum` that adds `__contains__()` method for values
- a change to the the parameter `impacted assets`:  all `CELO/Fiat` pairs are included and `BTC/Fiat`, `ETH/Fiat` are excluded as Celo network impact is currently unlikely 